### PR TITLE
fix colocate_actor_ref vllm engine still colocated bug

### DIFF
--- a/marti/controllers/multi_agent_controller.py
+++ b/marti/controllers/multi_agent_controller.py
@@ -229,7 +229,7 @@ class MultiAgentController(BaseController):
                     agent_config.enable_prefix_caching,
                     agent_config.enforce_eager,
                     max_len,
-                    pg,
+                    pg if agent_config.colocate_all_models else None,
                     agent_config.vllm_gpu_memory_utilization,
                     agent_config.vllm_enable_sleep
                 )


### PR DESCRIPTION
This PR fix a bug that, when not using hybrid engine and only colocating actor and reference model, vllm engine is still colocated with actor/ref.