### PR TITLE
Fix stale openrlhf references in single-agent examples 修复单智能体示例中过期的 openrlhf 引用

### DIFF
--- a/examples/single-agent/run_train_code_async.sh
+++ b/examples/single-agent/run_train_code_async.sh
@@ -2,7 +2,7 @@
 # gspo + tis + datafilter + overlong
 # set -x
 ROOT_DIR=""
-cd ROOT_DIR
+cd "${ROOT_DIR}"
 
 # basic config
 # set local model path
@@ -65,11 +65,11 @@ mkdir -p "./outputs/ckpt/${ADVANTAGE}-${SHORT_NAME}-${TASK}-db-${EXP}-agent1"
 
 
 
-python3 -m openrlhf.cli.multi_agent_train_ppo_ray \
+python3 -m marti.cli.multi_agent_train_ppo_ray \
     --default_agent "$DEFAULT_AGENT" \
     --agents "$AGENT0" \
     --workflow_args "$WORKFLOW_ARGS" \
-    --workflow_func_path openrlhf/agent_workflows/single_codeworkflow.py \
+    --workflow_func_path marti/agent_workflows/single_codeworkflow.py \
     --parallel_loading \
     --ref_num_nodes 1 \
     --ref_num_gpus_per_node 2 \

--- a/examples/single-agent/run_train_math_async.sh
+++ b/examples/single-agent/run_train_math_async.sh
@@ -64,11 +64,11 @@ mkdir -p "./outputs/ckpt/${ADVANTAGE}-${SHORT_NAME}-${TASK}-db-${EXP}-agent1"
 
 
 
-python3 -m openrlhf.cli.multi_agent_train_ppo_ray \
+python3 -m marti.cli.multi_agent_train_ppo_ray \
     --default_agent "$DEFAULT_AGENT" \
     --agents "$AGENT0" \
     --workflow_args "$WORKFLOW_ARGS" \
-    --workflow_func_path openrlhf/agent_workflows/single_mathworkflow.py \
+    --workflow_func_path marti/agent_workflows/single_mathworkflow.py \
     --parallel_loading \
     --ref_num_nodes 1 \
     --ref_num_gpus_per_node 2 \

--- a/marti/trainer/ray/vllm_engine.py
+++ b/marti/trainer/ray/vllm_engine.py
@@ -172,7 +172,7 @@ def create_vllm_engines(
             ).remote(
                 model=pretrain,
                 enforce_eager=enforce_eager,
-                worker_extension_cls="openrlhf.trainer.ray.vllm_worker_wrap.WorkerWrap",
+                worker_extension_cls="marti.trainer.ray.vllm_worker_wrap.WorkerWrap",
                 tensor_parallel_size=tensor_parallel_size,
                 seed=seed + i,
                 distributed_executor_backend=distributed_executor_backend,


### PR DESCRIPTION
## Summary / 总结

- Replace stale `openrlhf` CLI entrypoints in the single-agent example scripts with the MARTI entrypoint  
  将单Agent示例脚本中过时的 `openrlhf` CLI 入口点替换为 MARTI 入口点

- Fix single-agent workflow paths to use `marti/agent_workflows/...`  
  修复单Agent工作流路径，改用 `marti/agent_workflows/...`

- Fix the incorrect `cd ROOT_DIR` usage in `run_train_code_async.sh`  
  修正 `run_train_code_async.sh` 中错误的 `cd ROOT_DIR` 用法

- Update `marti/trainer/ray/vllm_engine.py` to use the MARTI worker wrapper path instead of the old `openrlhf` path  
  更新 `marti/trainer/ray/vllm_engine.py`，使用 MARTI 的 worker wrapper 路径，而不是旧的 `openrlhf` 路径

## Why / 原因

These stale references prevent the single-agent examples from matching the current package layout and can cause runtime failures such as `ModuleNotFoundError: No module named 'openrlhf'`.  
这些过时的引用导致单Agent示例无法匹配当前的包结构，并可能引发运行时错误，例如 `ModuleNotFoundError: No module named 'openrlhf'`。

## Scope / 范围

This PR intentionally stays focused on the single-agent path and the confirmed runtime blocker in `vllm_engine.py`.  
本PR有意聚焦于单Agent路径以及 `vllm_engine.py` 中已确认的运行时阻塞问题。

Other examples still contain similar stale references, but those will be better handled in a separate follow-up PR to keep this change easy to review.  
其他示例仍包含类似的过时引用，但这些问题将在单独的后续PR中处理，以保持本次变更易于审查。

## Test plan / 测试计划

- [x] verify `examples/single-agent/run_train_math_async.sh` uses `python3 -m marti.cli.multi_agent_train_ppo_ray`  
  验证 `examples/single-agent/run_train_math_async.sh` 使用 `python3 -m marti.cli.multi_agent_train_ppo_ray`

- [x] verify `examples/single-agent/run_train_math_async.sh` uses `marti/agent_workflows/single_mathworkflow.py`  
  验证 `examples/single-agent/run_train_math_async.sh` 使用 `marti/agent_workflows/single_mathworkflow.py`

- [x] verify `examples/single-agent/run_train_code_async.sh` uses `cd "${ROOT_DIR}"`  
  验证 `examples/single-agent/run_train_code_async.sh` 使用 `cd "${ROOT_DIR}"`

- [x] verify `examples/single-agent/run_train_code_async.sh` uses `python3 -m marti.cli.multi_agent_train_ppo_ray`  
  验证 `examples/single-agent/run_train_code_async.sh` 使用 `python3 -m marti.cli.multi_agent_train_ppo_ray`

- [x] verify `examples/single-agent/run_train_code_async.sh` uses `marti/agent_workflows/single_codeworkflow.py`  
  验证 `examples/single-agent/run_train_code_async.sh` 使用 `marti/agent_workflows/single_codeworkflow.py`

- [x] verify `marti/trainer/ray/vllm_engine.py` uses `marti.trainer.ray.vllm_worker_wrap.WorkerWrap`  
  验证 `marti/trainer/ray/vllm_engine.py` 使用 `marti.trainer.ray.vllm_worker_wrap.WorkerWrap`

- [x] confirm the previous `openrlhf` runtime import path is removed from the single-agent path  
  确认之前的 `openrlhf` 运行时导入路径已从单Agent路径中移除